### PR TITLE
GRANITE-29961 [Spectrum] Add support for ariaLabel and ariaLabelledby to Masonry component

### DIFF
--- a/coral-component-masonry/examples/index.html
+++ b/coral-component-masonry/examples/index.html
@@ -98,6 +98,14 @@
         </style>
 
         <label>
+          ariaGrid
+          <span id="ariaGrid">
+            <a href="#" class="coral-Link">off</a> |
+            <a href="#" class="coral-Link">on</a> |
+          </span>
+        </label>
+        <br>
+        <label>
           Selection mode
           <span id="selection">
             <a href="#" class="coral-Link">none</a> |
@@ -130,88 +138,94 @@
           <a href="#" class="coral-Link append" data-count="100">append 100</a> |
         </label>
         <i>(double click on item to remove it)</i>
-
-        <coral-masonry orderable id="masonry" layout="fixed-centered" columnwidth="250" orderable>
-          <coral-masonry-item class="coral-Well">
-            <article>
-              <span coral-masonry-draghandle></span>
-              With image
-              <img src="http://via.placeholder.com/600x300" alt="">
-            </article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>
-              <span coral-masonry-draghandle></span>
-              card
-              <br>card
-            </article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well" colspan="2">
-            <article>
-              <span coral-masonry-draghandle></span>
-              card
-              <br>card
-              <br>card
-            </article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>
-              <span coral-masonry-draghandle></span>
-              card
-              <br>card
-              <br>card
-              <br>card
-            </article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well" colspan="2">
-            <article>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well" colspan="2">
-            <article>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well" colspan="2">
-            <article>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-        </coral-masonry>
+        <div>
+          <coral-masonry orderable id="masonry" layout="fixed-centered" columnwidth="250" aria-label="Masonry">
+            <coral-masonry-item class="coral-Well">
+              <article>
+                <span coral-masonry-draghandle></span>
+                With image
+                <img src="http://via.placeholder.com/600x300" alt="">
+              </article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>
+                <span coral-masonry-draghandle></span>
+                card
+                <br>card
+              </article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well" colspan="2">
+              <article>
+                <span coral-masonry-draghandle></span>
+                card
+                <br>card
+                <br>card
+              </article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>
+                <span coral-masonry-draghandle></span>
+                card
+                <br>card
+                <br>card
+                <br>card
+              </article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well" colspan="2">
+              <article>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well" colspan="2">
+              <article>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well" colspan="2">
+              <article>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+          </coral-masonry>
+        </div>
         <script>
           window.addEventListener('load', function() {
             const masonry = document.getElementById('masonry');
+
+            const ariaGridSelector = document.getElementById('ariaGrid');
+            ariaGridSelector.addEventListener('click', function(event) {
+              masonry.setAttribute('ariagrid', event.target.textContent);
+            });
 
             const layoutSelector = document.getElementById('layout');
             layoutSelector.addEventListener('click', function(event) {

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -392,6 +392,68 @@ class Masonry extends BaseComponent(HTMLElement) {
     this._updateAriaRoleForItems(this._ariaGrid);
   }
 
+  /**
+   Specifies aria-label value
+   
+   @type {?String}
+   @htmlattribute aria-label
+   @htmlattributereflected
+   */
+  get ariaLabel() {
+    return this.getAttribute('aria-label');
+  }
+  set ariaLabel(value) {
+    value = transform.string(value);
+    if (value === '') {
+      this.removeAttribute('aria-label');
+    }
+    else {
+      this._reflectAttribute('aria-label', value);
+    }
+
+    if (!this.parentElement || this._ariaGrid === ariaGrid.OFF) {
+      return;
+    }
+    
+    if (this.ariaLabel) {
+      this.parentElement.setAttribute('aria-label', this.ariaLabel);
+    }
+    else {
+      this.parentElement.removeAttribute('aria-label');
+    }
+  }
+
+  /**
+   Specifies aria-labelledby value
+   
+   @type {?String}
+   @htmlattribute aria-labelledby
+   @htmlattributereflected
+   */
+  get ariaLabelledby() {
+    return this.getAttribute('aria-labelledby');
+  }
+  set ariaLabelledby(value) {
+    value = transform.string(value);
+    if (value === '') {
+      this.removeAttribute('aria-labelledby');
+    }
+    else {
+      this._reflectAttribute('aria-labelledby', value);
+    }
+
+    if (!this.parentElement || this._ariaGrid === ariaGrid.OFF) {
+      return;
+    }
+    
+    if (this.ariaLabelledby) {
+      this.parentElement.setAttribute('aria-labelledby', this.ariaLabelledby);
+    }
+    else {
+      this.parentElement.removeAttribute('aria-labelledby');
+    }
+  }
+
   /** @private */
   _updateAriaRoleForParent(activateAriaGrid) {
     if (!this.parentElement) {
@@ -402,6 +464,17 @@ class Masonry extends BaseComponent(HTMLElement) {
       // Save/set role for the parent as grid
       this._preservedParentAriaRole = this.parentElement.getAttribute('role');
       this.parentElement.setAttribute('role', 'grid');
+
+      // parent grid should be labelled the same as coral-masonry
+      if (this.ariaLabel && this.parentElement.getAttribute('aria-label') !== this.ariaLabel) {
+        this._preservedParentAriaLabel = this.parentElement.getAttribute('aria-label');
+        this.parentElement.setAttribute('aria-label', this.ariaLabel);
+      }
+
+      if (this.ariaLabelledby && this.parentElement.getAttribute('aria-labelledby') !== this.ariaLabelledby) {
+        this._preservedParentAriaLabelledby = this.parentElement.getAttribute('aria-labelledby');
+        this.parentElement.setAttribute('aria-labelledby', this.ariaLabelledby);
+      }
     }
     else {
       // Restore/remove role of the parent element
@@ -410,6 +483,22 @@ class Masonry extends BaseComponent(HTMLElement) {
       }
       else {
         this.parentElement.removeAttribute('role');
+      }
+
+      // restore the aria-label or aria-labelledby values as well
+      if (this._preservedParentAriaLabel) {
+        this.parentElement.setAttribute('aria-label', this._preservedParentAriaLabel);
+        this._preservedParentAriaLabel = undefined;
+      }
+      else {
+        this.parentElement.removeAttribute('aria-label');
+      }
+
+      if (this._preservedParentAriaLabelledby !== undefined) {
+        this.parentElement.setAttribute('aria-labelledby', this._preservedParentAriaLabelledby);
+      }
+      else {
+        this.parentElement.removeAttribute('aria-labelledby');
       }
 
       // Remove aria-colcount
@@ -929,7 +1018,9 @@ class Masonry extends BaseComponent(HTMLElement) {
   static get _attributePropertyMap() {
     return commons.extend(super._attributePropertyMap, {
       selectionmode: 'selectionMode',
-      ariagrid: 'ariaGrid'
+      ariagrid: 'ariaGrid',
+      'aria-label': 'ariaLabel',
+      'aria-labelledby': 'ariaLabelledby',
     });
   }
   
@@ -940,7 +1031,9 @@ class Masonry extends BaseComponent(HTMLElement) {
       'layout',
       'spacing',
       'orderable',
-      'ariagrid'
+      'ariagrid',
+      'aria-label',
+      'aria-labelledby'
     ]);
   }
   

--- a/coral-component-masonry/src/tests/snippets/Masonry.ariagrid.html
+++ b/coral-component-masonry/src/tests/snippets/Masonry.ariagrid.html
@@ -1,5 +1,5 @@
-<div>
-  <coral-masonry role="region" ariagrid="on">
+<div aria-label="Parent Label" aria-labelledby="Parent Labelledby">
+  <coral-masonry role="region" ariagrid="on" aria-label="Masonry Label" aria-labelledby="Masonry Labelledby">
     <coral-masonry-item>item1</coral-masonry-item>
     <coral-masonry-item>item2</coral-masonry-item>
     <coral-masonry-item>item3</coral-masonry-item>

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -500,6 +500,9 @@ describe('Masonry.Layout', function() {
       
       expect(el.parentElement.getAttribute('role')).to.equal('grid','Parent element should have role="grid"');
       expect(el.parentElement.getAttribute('aria-colcount')).to.equal('3','Parent element should have correct aria-colcount');
+      expect(el.parentElement.getAttribute('aria-label')).to.equal('Masonry Label', 'Masonry parent element should receive same aria-label as Masonry');
+      expect(el.parentElement.getAttribute('aria-labelledby')).to.equal('Masonry Labelledby', 'Masonry parent element should receive same aria-labelledby as Masonry');
+
       expect(el.getAttribute('role')).to.equal('row','<coral-masonry> should have role="row"');
       expect(el.items.first().getAttribute('role'))
         .to.equal('gridcell','<coral-masonry-item> should have role="gridcell"');
@@ -512,7 +515,10 @@ describe('Masonry.Layout', function() {
         .to.equal(null,'Parent element should have role=null after deactivating ariagrid');
       expect(el.parentElement.getAttribute('aria-colcount'))
         .to.equal(null,'Parent element should not have aria-colcount after deactivating ariagrid');
-      expect(el.getAttribute('role'))
+      expect(el.parentElement.getAttribute('aria-label')).to.equal('Parent Label', 'Masonry parent element should restore cached aria-label when ariaGrid is set to "off".');
+      expect(el.parentElement.getAttribute('aria-labelledby')).to.equal('Parent Labelledby', 'Masonry parent element should restore cached aria-labelledby when ariaGrid is set to "off".');
+  
+        expect(el.getAttribute('role'))
         .to.equal('region','<coral-masonry> should have role="region" after deactivating ariagrid');
       expect(el.items.first().getAttribute('role'))
         .to.equal(null,'<coral-masonry-item> should have no role"');
@@ -523,6 +529,8 @@ describe('Masonry.Layout', function() {
       el.ariaGrid = "on";
       expect(el.parentElement.getAttribute('role')).to.equal('grid','Parent element should have role="grid"');
       expect(el.parentElement.getAttribute('aria-colcount')).to.equal('3','Parent element should have correct aria-colcount');
+      expect(el.parentElement.getAttribute('aria-label')).to.equal('Masonry Label', 'Masonry parent element should receive same aria-label as Masonry');
+      expect(el.parentElement.getAttribute('aria-labelledby')).to.equal('Masonry Labelledby', 'Masonry parent element should receive same aria-labelledby as Masonry');
     });
 
   });


### PR DESCRIPTION
## Description
Add support for ariaLabel and ariaLabelledby to coral-component-masonry in Coral-Spectrum. It's important to be able to label the grid defined by coral-masonry, rather than the row that coral-masonry becomes.

## Related Issue
[GRANITE-29961](https://jira.corp.adobe.com/browse/GRANITE-29961),
[CQ-4294648](https://jira.corp.adobe.com/browse/CQ-4294648)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
